### PR TITLE
[Issue 5] introduce helper to turbo train

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
         ruby-version:
           - "2.7"
           - "3.0"
+          - "3.2.2"
         rails-version:
           - "6.1"
           - "7.0"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /test/dummy/tmp/
 Gemfile.lock
 .DS_Store
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,11 @@ group :test do
   gem 'puma'
   gem 'capybara'
   gem 'rexml'
+  # Locked because on 4.9.1 getting error:
+  # BroadcastingTest#test_Turbo::Train_broadcasts_Turbo_Streams:
+  # ArgumentError: wrong number of arguments (given 2, expected 0..1)
+  #     selenium-webdriver-4.9.1/lib/selenium/webdriver/common/logger.rb:51:in `initialize'
+  # https://github.com/SeleniumHQ/selenium/issues/12013
   gem 'selenium-webdriver', '4.9.0'
   gem 'webdrivers'
   gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem 'puma'
   gem 'capybara'
   gem 'rexml'
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '4.9.0'
   gem 'webdrivers'
   gem 'sqlite3'
 end

--- a/app/helpers/turbo/train/streams_helper.rb
+++ b/app/helpers/turbo/train/streams_helper.rb
@@ -2,7 +2,7 @@ module Turbo::Train::StreamsHelper
   def turbo_train_from(*streamables, **attributes)
     attributes[:name] = Turbo::Train.signed_stream_name(streamables)
     attributes[:session] = Turbo::Train.encode({ platform: "web" })
-    attributes[:href] = Turbo::Train.url
+    attributes[:href] = Turbo::Train.configuration.url
     tag.turbo_train_stream_source(**attributes)
   end
 end

--- a/app/jobs/turbo/train/action_broadcast_job.rb
+++ b/app/jobs/turbo/train/action_broadcast_job.rb
@@ -1,0 +1,16 @@
+module Turbo
+  module Train
+    class ActionBroadcastJob < ActiveJob::Base
+      discard_on ActiveJob::DeserializationError
+
+      def perform(stream, action:, target:, **rendering)
+        Turbo::Train.broadcast_action_to(
+          stream,
+          action: action,
+          target: target,
+          **rendering
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/turbo/train/broadcast_job.rb
+++ b/app/jobs/turbo/train/broadcast_job.rb
@@ -1,0 +1,11 @@
+module Turbo
+  module Train
+    class BroadcastJob < ActiveJob::Base
+      discard_on ActiveJob::DeserializationError
+
+      def perform(stream, **rendering)
+        Turbo::Train.broadcast_render_to(stream, **rendering)
+      end
+    end
+  end
+end

--- a/app/models/concerns/turbo/train/broadcastable.rb
+++ b/app/models/concerns/turbo/train/broadcastable.rb
@@ -1,0 +1,300 @@
+# Based on: Turbo::Broadcastable
+module Turbo::Train::Broadcastable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Configures the model to broadcast creates, updates, and destroys to a stream name derived at runtime by the
+    # <tt>stream</tt> symbol invocation. By default, the creates are appended to a dom id target name derived from
+    # the model's plural name. The insertion can also be made to be a prepend by overwriting <tt>inserts_by</tt> and
+    # the target dom id overwritten by passing <tt>target</tt>. Examples:
+    #
+    #   class Message < ApplicationRecord
+    #     belongs_to :board
+    #     broadcasts_to :board
+    #   end
+    #
+    #   class Message < ApplicationRecord
+    #     belongs_to :board
+    #     train_broadcasts_to ->(message) { [ message.board, :messages ] }, inserts_by: :prepend, target: "board_messages"
+    #   end
+    #
+    #   class Message < ApplicationRecord
+    #     belongs_to :board
+    #     train_broadcasts_to ->(message) { [ message.board, :messages ] }, partial: "messages/custom_message"
+    #   end
+    def train_broadcasts_to(stream, inserts_by: :append, target: train_broadcast_target_default, **rendering)
+      after_create_commit  -> { train_broadcast_action_later_to(stream.try(:call, self) || send(stream), action: inserts_by, target: target.try(:call, self) || target, **rendering) }
+      after_update_commit  -> { train_broadcast_replace_later_to(stream.try(:call, self) || send(stream), **rendering) }
+      after_destroy_commit -> { train_broadcast_remove_to(stream.try(:call, self) || send(stream)) }
+    end
+
+    # Same as <tt>#train_broadcasts_to</tt>, but the designated stream for updates and destroys is automatically set to
+    # the current model, for creates - to the model plural name, which can be overriden by passing <tt>stream</tt>.
+    def train_broadcasts(stream = model_name.plural, inserts_by: :append, target: train_broadcast_target_default, **rendering)
+      after_create_commit  -> { train_broadcast_action_later_to(stream, action: inserts_by, target: target.try(:call, self) || target, **rendering) }
+      after_update_commit  -> { train_broadcast_replace_later(**rendering) }
+      after_destroy_commit -> { train_broadcast_remove }
+    end
+
+    # All default targets will use the return of this method. Overwrite if you want something else than <tt>model_name.plural</tt>.
+    def train_broadcast_target_default
+      model_name.plural
+    end
+  end
+
+  # Remove this broadcastable model from the dom for subscribers of the stream name identified by the passed streamables.
+  # Example:
+  #
+  #   # Sends <turbo-stream action="remove" target="clearance_5"></turbo-stream> to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_remove_to examiner.identity, :clearances
+  def train_broadcast_remove_to(*streamables, target: self)
+    Turbo::Train.broadcast_remove_to(*streamables, target: target)
+  end
+
+  # Same as <tt>#train_broadcast_remove_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_remove
+    train_broadcast_remove_to self
+  end
+
+  # Replace this broadcastable model in the dom for subscribers of the stream name identified by the passed
+  # <tt>streamables</tt>. The rendering parameters can be set by appending named arguments to the call. Examples:
+  #
+  #   # Sends <turbo-stream action="replace" target="clearance_5"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_replace_to examiner.identity, :clearances
+  #
+  #   # Sends <turbo-stream action="replace" target="clearance_5"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_replace_to examiner.identity, :clearances, partial: "clearances/other_partial", locals: { a: 1 }
+  def train_broadcast_replace_to(*streamables, **rendering)
+    Turbo::Train.broadcast_replace_to(*streamables, target: self, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_replace_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_replace(**rendering)
+    train_broadcast_replace_to self, **rendering
+  end
+
+  # Update this broadcastable model in the dom for subscribers of the stream name identified by the passed
+  # <tt>streamables</tt>. The rendering parameters can be set by appending named arguments to the call. Examples:
+  #
+  #   # Sends <turbo-stream action="update" target="clearance_5"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_update_to examiner.identity, :clearances
+  #
+  #   # Sends <turbo-stream action="update" target="clearance_5"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_update_to examiner.identity, :clearances, partial: "clearances/other_partial", locals: { a: 1 }
+  def train_broadcast_update_to(*streamables, **rendering)
+    Turbo::Train.broadcast_update_to(*streamables, target: self, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#broadcast_update_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_update(**rendering)
+    train_broadcast_update_to self, **rendering
+  end
+
+  # Insert a rendering of this broadcastable model before the target identified by it's dom id passed as <tt>target</tt>
+  # for subscribers of the stream name identified by the passed <tt>streamables</tt>. The rendering parameters can be set by
+  # appending named arguments to the call. Examples:
+  #
+  #   # Sends <turbo-stream action="before" target="clearance_5"><template><div id="clearance_4">My Clearance</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_before_to examiner.identity, :clearances, target: "clearance_5"
+  #
+  #   # Sends <turbo-stream action="before" target="clearance_5"><template><div id="clearance_4">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_before_to examiner.identity, :clearances, target: "clearance_5",
+  #     partial: "clearances/other_partial", locals: { a: 1 }
+  def train_broadcast_before_to(*streamables, target:, **rendering)
+    Turbo::Train.broadcast_before_to(*streamables, target: target, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Insert a rendering of this broadcastable model after the target identified by it's dom id passed as <tt>target</tt>
+  # for subscribers of the stream name identified by the passed <tt>streamables</tt>. The rendering parameters can be set by
+  # appending named arguments to the call. Examples:
+  #
+  #   # Sends <turbo-stream action="after" target="clearance_5"><template><div id="clearance_6">My Clearance</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_after_to examiner.identity, :clearances, target: "clearance_5"
+  #
+  #   # Sends <turbo-stream action="after" target="clearance_5"><template><div id="clearance_6">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_after_to examiner.identity, :clearances, target: "clearance_5",
+  #     partial: "clearances/other_partial", locals: { a: 1 }
+  def train_broadcast_after_to(*streamables, target:, **rendering)
+    Turbo::Train.broadcast_after_to(*streamables, target: target, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Append a rendering of this broadcastable model to the target identified by it's dom id passed as <tt>target</tt>
+  # for subscribers of the stream name identified by the passed <tt>streamables</tt>. The rendering parameters can be set by
+  # appending named arguments to the call. Examples:
+  #
+  #   # Sends <turbo-stream action="append" target="clearances"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_append_to examiner.identity, :clearances, target: "clearances"
+  #
+  #   # Sends <turbo-stream action="append" target="clearances"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_append_to examiner.identity, :clearances, target: "clearances",
+  #     partial: "clearances/other_partial", locals: { a: 1 }
+  def train_broadcast_append_to(*streamables, target: train_broadcast_target_default, **rendering)
+    Turbo::Train.broadcast_append_to(*streamables, target: target, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_append_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_append(target: train_broadcast_target_default, **rendering)
+    train_broadcast_append_to self, target: target, **rendering
+  end
+
+  # Prepend a rendering of this broadcastable model to the target identified by it's dom id passed as <tt>target</tt>
+  # for subscribers of the stream name identified by the passed <tt>streamables</tt>. The rendering parameters can be set by
+  # appending named arguments to the call. Examples:
+  #
+  #   # Sends <turbo-stream action="prepend" target="clearances"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_prepend_to examiner.identity, :clearances, target: "clearances"
+  #
+  #   # Sends <turbo-stream action="prepend" target="clearances"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_prepend_to examiner.identity, :clearances, target: "clearances",
+  #     partial: "clearances/other_partial", locals: { a: 1 }
+  def train_broadcast_prepend_to(*streamables, target: train_broadcast_target_default, **rendering)
+    Turbo::Train.broadcast_prepend_to(*streamables, target: target, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_prepend_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_prepend(target: train_broadcast_target_default, **rendering)
+    train_broadcast_prepend_to self, target: target, **rendering
+  end
+
+  # Broadcast a named <tt>action</tt>, allowing for dynamic dispatch, instead of using the concrete action methods. Examples:
+  #
+  #   # Sends <turbo-stream action="prepend" target="clearances"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.train_broadcast_action_to examiner.identity, :clearances, action: :prepend, target: "clearances"
+  def train_broadcast_action_to(*streamables, action:, target: train_broadcast_target_default, **rendering)
+    Turbo::Train.broadcast_action_to(*streamables, action: action, target: target, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_action_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_action(action, target: train_broadcast_target_default, **rendering)
+    train_broadcast_action_to self, action: action, target: target, **rendering
+  end
+
+
+  # Same as <tt>train_broadcast_replace_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
+  def train_broadcast_replace_later_to(*streamables, **rendering)
+    Turbo::Train.broadcast_replace_later_to(*streamables, target: self, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_replace_later_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_replace_later(**rendering)
+    train_broadcast_replace_later_to self, **rendering
+  end
+
+  # Same as <tt>train_broadcast_update_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
+  def train_broadcast_update_later_to(*streamables, **rendering)
+    Turbo::Train.broadcast_update_later_to(*streamables, target: self, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_update_later_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_update_later(**rendering)
+    train_broadcast_update_later_to self, **rendering
+  end
+
+  # Same as <tt>train_broadcast_append_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
+  def train_broadcast_append_later_to(*streamables, target: train_broadcast_target_default, **rendering)
+    Turbo::Train.broadcast_append_later_to(*streamables, target: target, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_append_later_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_append_later(target: train_broadcast_target_default, **rendering)
+    train_broadcast_append_later_to self, target: target, **rendering
+  end
+
+  # Same as <tt>train_broadcast_prepend_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
+  def train_broadcast_prepend_later_to(*streamables, target: train_broadcast_target_default, **rendering)
+    Turbo::Train.broadcast_prepend_later_to(*streamables, target: target, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_prepend_later_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_prepend_later(target: train_broadcast_target_default, **rendering)
+    train_broadcast_prepend_later_to self, target: target, **rendering
+  end
+
+  # Same as <tt>train_broadcast_action_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
+  def train_broadcast_action_later_to(*streamables, action:, target: train_broadcast_target_default, **rendering)
+    Turbo::Train.broadcast_action_later_to(*streamables, action: action, target: target, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>#train_broadcast_action_later_to</tt>, but the designated stream is automatically set to the current model.
+  def train_broadcast_action_later(action:, target: train_broadcast_target_default, **rendering)
+    train_broadcast_action_later_to self, action: action, target: target, **rendering
+  end
+
+  # Render a turbo stream template with this broadcastable model passed as the local variable. Example:
+  #
+  #   # Template: entries/_entry.turbo_stream.erb
+  #   <%= turbo_stream.remove entry %>
+  #
+  #   <%= turbo_stream.append "entries", entry if entry.active? %>
+  #
+  # Sends:
+  #
+  #   <turbo-stream action="remove" target="entry_5"></turbo-stream>
+  #   <turbo-stream action="append" target="entries"><template><div id="entry_5">My Entry</div></template></turbo-stream>
+  #
+  # ...to the stream named "entry:5".
+  #
+  # Note that rendering inline via this method will cause template rendering to happen synchronously. That is usually not
+  # desireable for model callbacks, certainly not if those callbacks are inside of a transaction. Most of the time you should
+  # be using `train_broadcast_render_later`, unless you specifically know why synchronous rendering is needed.
+  def train_broadcast_render(**rendering)
+    train_broadcast_render_to self, **rendering
+  end
+
+  # Same as <tt>train_broadcast_render</tt> but run with the added option of naming the stream using the passed
+  # <tt>streamables</tt>.
+  #
+  # Note that rendering inline via this method will cause template rendering to happen synchronously. That is usually not
+  # desireable for model callbacks, certainly not if those callbacks are inside of a transaction. Most of the time you should
+  # be using `train_broadcast_render_later_to`, unless you specifically know why synchronous rendering is needed.
+  def train_broadcast_render_to(*streamables, **rendering)
+    Turbo::Train.broadcast_render_to(*streamables, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>train_broadcast_action_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
+  def train_broadcast_render_later(**rendering)
+    train_broadcast_render_later_to self, **rendering
+  end
+
+  # Same as <tt>train_broadcast_render_later</tt> but run with the added option of naming the stream using the passed
+  # <tt>streamables</tt>.
+  def train_broadcast_render_later_to(*streamables, **rendering)
+    Turbo::Train.broadcast_render_later_to(*streamables, **train_broadcast_rendering_with_defaults(rendering))
+  end
+
+
+  private
+  def train_broadcast_target_default
+    self.class.train_broadcast_target_default
+  end
+
+  def train_broadcast_rendering_with_defaults(options)
+    options.tap do |o|
+      # Add the current instance into the locals with the element name (which is the un-namespaced name)
+      # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
+      o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
+
+      if o[:html] || o[:partial]
+        return o
+      elsif o[:template]
+        o[:layout] = false
+      else
+        # if none of these options are passed in, it will set a partial from #to_partial_path
+        o[:partial] ||= to_partial_path
+      end
+    end
+  end
+end

--- a/lib/turbo/train.rb
+++ b/lib/turbo/train.rb
@@ -1,3 +1,7 @@
 require "turbo/train/version"
 require "turbo/train/config"
+require 'turbo/train/broadcasts'
+require 'turbo/train/server'
+require 'turbo/train/test_server'
+require 'turbo/train/test_helper'
 require "turbo/train/engine"

--- a/lib/turbo/train/broadcasts.rb
+++ b/lib/turbo/train/broadcasts.rb
@@ -84,4 +84,8 @@ module Turbo::Train::Broadcasts
   def broadcast_prepend_later_to(*streamables, **opts)
     broadcast_action_later_to(*streamables, action: :prepend, **opts)
   end
+
+  def broadcast_render_later_to(*streamables, **rendering)
+    Turbo::Train::BroadcastJob.perform_later streamables, **rendering
+  end
 end

--- a/lib/turbo/train/broadcasts.rb
+++ b/lib/turbo/train/broadcasts.rb
@@ -1,0 +1,87 @@
+module Turbo::Train::Broadcasts
+  def broadcast(streamables, content:)
+    topics = if streamables.is_a?(Array)
+               streamables.map { |s| signed_stream_name(s) }
+             else
+               [signed_stream_name(streamables)]
+             end
+
+    data = {
+      topic: topics,
+      data: content
+    }
+
+    Turbo::Train.server.publish(topics: topics, data: data)
+  end
+
+  def broadcast_action_to(*streamables, action:, target: nil, targets: nil, **rendering)
+    broadcast(streamables, content: turbo_stream_action_tag(action, target: target, targets: targets, template:
+      rendering.delete(:content) || rendering.delete(:html) || (rendering.any? ? render_format(:html, **rendering) : nil)
+    ))
+  end
+
+  def broadcast_render_to(*streamables, **rendering)
+    broadcast(*streamables, content: render_format(:turbo_stream, **rendering))
+  end
+
+  def broadcast_remove_to(*streamables, **opts)
+    broadcast_action_to(*streamables, action: :remove, **opts)
+  end
+
+  def broadcast_replace_to(*streamables, **opts)
+    broadcast_action_to(*streamables, action: :replace, **opts)
+  end
+
+  def broadcast_update_to(*streamables, **opts)
+    broadcast_action_to(*streamables, action: :update, **opts)
+  end
+
+  def broadcast_before_to(*streamables, **opts)
+    broadcast_action_to(*streamables, action: :before, **opts)
+  end
+
+  def broadcast_after_to(*streamables, **opts)
+    broadcast_action_to(*streamables, action: :after, **opts)
+  end
+
+  def broadcast_append_to(*streamables, **opts)
+    broadcast_action_to(*streamables, action: :append, **opts)
+  end
+
+  def broadcast_prepend_to(*streamables, **opts)
+    broadcast_action_to(*streamables, action: :prepend, **opts)
+  end
+
+  # later
+  def broadcast_action_later_to(*streamables, action:, target: nil, targets: nil, **rendering)
+    Turbo::Train::ActionBroadcastJob.perform_later streamables, action: action, target: target, targets: targets, **rendering
+  end
+
+  def broadcast_replace_later_to(*streamables, **opts)
+    broadcast_action_later_to(*streamables, action: :replace, **opts)
+  end
+
+  def broadcast_remove_later_to(*streamables, **opts)
+    broadcast_action_later_to(*streamables, action: :remove, **opts)
+  end
+
+  def broadcast_update_later_to(*streamables, **opts)
+    broadcast_action_later_to(*streamables, action: :update, **opts)
+  end
+
+  def broadcast_before_later_to(*streamables, **opts)
+    broadcast_action_later_to(*streamables, action: :before, **opts)
+  end
+
+  def broadcast_after_later_to(*streamables, **opts)
+    broadcast_action_later_to(*streamables, action: :after, **opts)
+  end
+
+  def broadcast_append_later_to(*streamables, **opts)
+    broadcast_action_later_to(*streamables, action: :append, **opts)
+  end
+
+  def broadcast_prepend_later_to(*streamables, **opts)
+    broadcast_action_later_to(*streamables, action: :prepend, **opts)
+  end
+end

--- a/lib/turbo/train/config.rb
+++ b/lib/turbo/train/config.rb
@@ -9,6 +9,10 @@ module Turbo
         @subscriber_key = 'testing'
         @skip_ssl_verification = Rails.env.development? || Rails.env.test?
       end
+
+      def url
+        "https://#{mercure_domain}/.well-known"
+      end
     end
 
     class << self

--- a/lib/turbo/train/server.rb
+++ b/lib/turbo/train/server.rb
@@ -1,0 +1,35 @@
+module Turbo
+  module Train
+    class Server
+      attr_reader :configuration
+
+      def initialize(configuration)
+        @configuration = configuration
+      end
+
+      def publish(topics:, data:)
+        payload = { mercure: { publish: topics } }
+        token = JWT.encode payload, configuration.publisher_key, ALGORITHM
+
+        uri = URI("#{configuration.url}/mercure")
+
+        req = Net::HTTP::Post.new(uri)
+        req['Content-Type'] = 'application/x-www-form-urlencoded'
+        req['Authorization'] = "Bearer #{token}"
+
+        req.body = URI.encode_www_form(data)
+        opts = {
+          use_ssl: uri.scheme == 'https'
+        }
+
+        if configuration.skip_ssl_verification
+          opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
+        end
+
+        Net::HTTP.start(uri.host, uri.port, opts) do |http|
+          http.request(req)
+        end
+      end
+    end
+  end
+end

--- a/lib/turbo/train/test_helper.rb
+++ b/lib/turbo/train/test_helper.rb
@@ -12,7 +12,7 @@ module Turbo
         Turbo::Train.instance_variable_set(:@server, Turbo::Train::Server.new(Turbo::Train.configuration))
       end
 
-      def train_assert_broadcast_on(stream, data, &block)
+      def assert_broadcast_on(stream, data, &block)
         signed_stream_name = Turbo::Train.signed_stream_name(stream)
 
         new_messages = Turbo::Train.server.broadcasts(signed_stream_name)

--- a/lib/turbo/train/test_helper.rb
+++ b/lib/turbo/train/test_helper.rb
@@ -29,7 +29,12 @@ module Turbo
         end
 
         message = new_messages.find { |msg| msg == data }
-        assert message, "No messages sent with #{data} to #{stream}"
+        if message.nil?
+          puts "signed_stream_name => #{signed_stream_name}"
+          puts "channels_data: #{Turbo::Train.server.channels_data.inspect}}"
+        end
+
+        assert message, "No messages sent with #{data} to #{Turbo::Train.stream_name_from(stream)}"
       end
     end
   end

--- a/lib/turbo/train/test_helper.rb
+++ b/lib/turbo/train/test_helper.rb
@@ -1,0 +1,36 @@
+# Based on: ActionCable::TestHelper
+module Turbo
+  module Train
+    module TestHelper
+      def before_setup
+        Turbo::Train.instance_variable_set(:@server, Turbo::Train::TestServer.new(Turbo::Train.configuration))
+        super
+      end
+
+      def after_teardown
+        super
+        Turbo::Train.instance_variable_set(:@server, Turbo::Train::Server.new(Turbo::Train.configuration))
+      end
+
+      def train_assert_broadcast_on(stream, data, &block)
+        signed_stream_name = Turbo::Train.signed_stream_name(stream)
+
+        new_messages = Turbo::Train.server.broadcasts(signed_stream_name)
+        if block_given?
+          old_messages = new_messages
+          Turbo::Train.server.clear_messages(signed_stream_name)
+
+          assert_nothing_raised(&block)
+          new_messages = Turbo::Train.server.broadcasts(signed_stream_name)
+          Turbo::Train.server.clear_messages(signed_stream_name)
+
+          # Restore all sent messages
+          (old_messages + new_messages).each { |m| Turbo::Train.server.broadcasts(signed_stream_name) << m }
+        end
+
+        message = new_messages.find { |msg| msg == data }
+        assert message, "No messages sent with #{data} to #{stream}"
+      end
+    end
+  end
+end

--- a/lib/turbo/train/test_server.rb
+++ b/lib/turbo/train/test_server.rb
@@ -1,12 +1,11 @@
 module Turbo
   module Train
-    class TestServer
+    class TestServer < Server
       attr_reader :configuration, :channels_data
 
       def initialize(configuration)
         @configuration = configuration
         @channels_data = {}
-        @real_server = Turbo::Train::Server.new(configuration)
       end
 
       def publish(topics:, data:)
@@ -14,8 +13,8 @@ module Turbo
           @channels_data[topic] ||= []
           @channels_data[topic] << data[:data]
         end
-        puts @channels_data
-        @real_server.publish(topics: topics, data: data)
+
+        super
       end
 
       def broadcasts(channel)

--- a/lib/turbo/train/test_server.rb
+++ b/lib/turbo/train/test_server.rb
@@ -1,0 +1,34 @@
+module Turbo
+  module Train
+    class TestServer
+      attr_reader :configuration, :channels_data
+
+      def initialize(configuration)
+        @configuration = configuration
+        @channels_data = {}
+        @real_server = Turbo::Train::Server.new(configuration)
+      end
+
+      def publish(topics:, data:)
+        Array(topics).each do |topic|
+          @channels_data[topic] ||= []
+          @channels_data[topic] << data[:data]
+        end
+        puts @channels_data
+        @real_server.publish(topics: topics, data: data)
+      end
+
+      def broadcasts(channel)
+        channels_data[channel] ||= []
+      end
+
+      def clear_messages(channel)
+        channels_data[channel] = []
+      end
+
+      def clear
+        @channels_data = []
+      end
+    end
+  end
+end

--- a/lib/turbo/train/train.rb
+++ b/lib/turbo/train/train.rb
@@ -30,6 +30,10 @@ module Turbo
         end
       end
 
+      def url
+        configuration.url
+      end
+
       private
 
       def render_format(format, **rendering)

--- a/lib/turbo/train/train.rb
+++ b/lib/turbo/train/train.rb
@@ -4,14 +4,11 @@ require 'net/http'
 module Turbo
   module Train
     extend Turbo::Streams::ActionHelper
+    extend Broadcasts
 
     ALGORITHM = "HS256"
 
     class << self
-      def url
-        "https://#{configuration.mercure_domain}/.well-known"
-      end
-
       def encode(payload)
         structured_payload = { mercure: { payload: payload } }
         JWT.encode structured_payload, configuration.subscriber_key, ALGORITHM
@@ -21,85 +18,14 @@ module Turbo
         Turbo.signed_stream_verifier.generate stream_name_from(streamables)
       end
 
-      def broadcast_action_to(*streamables, action:, target: nil, targets: nil, **rendering)
-        broadcast(streamables, content: turbo_stream_action_tag(action, target: target, targets: targets, template:
-          rendering.delete(:content) || rendering.delete(:html) || (rendering.any? ? render_format(:html, **rendering) : nil)
-        ))
-      end
-
-      def broadcast_render_to(*streamables, **rendering)
-        broadcast(*streamables, content: render_format(:turbo_stream, **rendering))
-      end
-
-      def broadcast_remove_to(*streamables, **opts)
-        broadcast_action_to(*streamables, action: :remove, **opts)
-      end
-
-      def broadcast_replace_to(*streamables, **opts)
-        broadcast_action_to(*streamables, action: :replace, **opts)
-      end
-
-      def broadcast_update_to(*streamables, **opts)
-        broadcast_action_to(*streamables, action: :update, **opts)
-      end
-
-      def broadcast_before_to(*streamables, **opts)
-        broadcast_action_to(*streamables, action: :before, **opts)
-      end
-
-      def broadcast_after_to(*streamables, **opts)
-        broadcast_action_to(*streamables, action: :after, **opts)
-      end
-
-      def broadcast_append_to(*streamables, **opts)
-        broadcast_action_to(*streamables, action: :append, **opts)
-      end
-
-      def broadcast_prepend_to(*streamables, **opts)
-        broadcast_action_to(*streamables, action: :prepend, **opts)
+      def server
+        @server ||= Server.new(configuration)
       end
 
       private
 
-      def domain
-        Rails.configuration.turbo_train.mercure_domain
-      end
-
       def render_format(format, **rendering)
         ApplicationController.render(formats: [ format ], **rendering)
-      end
-
-      def broadcast(streamables, content:)
-        topics = if streamables.is_a?(Array)
-          streamables.map { |s| signed_stream_name(s) }
-        else
-          [signed_stream_name(streamables)]
-        end
-
-        data = {
-          topic: topics,
-          data: content
-        }
-        payload = { mercure: { publish: topics } }
-        token = JWT.encode payload, configuration.publisher_key, ALGORITHM
-
-        uri = URI("#{url}/mercure")
-
-        req = Net::HTTP::Post.new(uri)
-        req['Content-Type'] = 'application/x-www-form-urlencoded'
-        req['Authorization'] = "Bearer #{token}"
-        req.body = URI.encode_www_form(data)
-        opts = {
-          use_ssl: uri.scheme == 'https'
-        }
-
-        if configuration.skip_ssl_verification
-          opts[:verify_mode] = OpenSSL::SSL::VERIFY_NONE
-        end
-
-        Net::HTTP.start(uri.host, uri.port, opts) do |http|
-          http.request(req)
-        end
       end
 
       def stream_name_from(streamables)

--- a/lib/turbo/train/train.rb
+++ b/lib/turbo/train/train.rb
@@ -22,18 +22,18 @@ module Turbo
         @server ||= Server.new(configuration)
       end
 
-      private
-
-      def render_format(format, **rendering)
-        ApplicationController.render(formats: [ format ], **rendering)
-      end
-
       def stream_name_from(streamables)
         if streamables.is_a?(Array)
           streamables.map  { |streamable| stream_name_from(streamable) }.join(":")
         else
           streamables.then { |streamable| streamable.try(:to_gid_param) || streamable.to_param }
         end
+      end
+
+      private
+
+      def render_format(format, **rendering)
+        ApplicationController.render(formats: [ format ], **rendering)
       end
     end
   end

--- a/lib/turbo/train/version.rb
+++ b/lib/turbo/train/version.rb
@@ -1,5 +1,5 @@
 module Turbo
   module Train
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  driven_by :selenium, screen_size: [1400, 1400]
 
   def assert_no_javascript_errors
     before = page.driver.browser.logs.get(:browser)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, screen_size: [1400, 1400]
+  if ENV['CI']
+    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  else
+    driven_by :selenium, screen_size: [1400, 1400]
+  end
 
   def assert_no_javascript_errors
     before = page.driver.browser.logs.get(:browser)

--- a/test/dummy/app/views/messages/_message.turbo_stream.erb
+++ b/test/dummy/app/views/messages/_message.turbo_stream.erb
@@ -1,11 +1,1 @@
-<%= turbo_stream.replace ENV["TEST_MSG_ID"] do %>
-  <div id="<%= ENV["TEST_MSG_ID"] + message.id.to_s %>">
-    <div>
-      <%= message.user.name %>
-    </div>
-    <div>
-      <%= message.text %>
-    </div>
-    <br/>
-  </div>
-<% end %>
+<%= turbo_stream.replace "message_1" do %>Goodbye!<% end %>

--- a/test/dummy/app/views/messages/_message.turbo_stream.erb
+++ b/test/dummy/app/views/messages/_message.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.replace ENV["TEST_MSG_ID"] do %>
+  <div id="<%= ENV["TEST_MSG_ID"] + message.id.to_s %>">
+    <div>
+      <%= message.user.name %>
+    </div>
+    <div>
+      <%= message.text %>
+    </div>
+    <br/>
+  </div>
+<% end %>

--- a/test/dummy/config/initializers/turbo_train.rb
+++ b/test/dummy/config/initializers/turbo_train.rb
@@ -1,5 +1,5 @@
 Turbo::Train.configure do |config|
-  config.mercure_domain = ENV['MERCURE_DOMAIN']
-  config.publisher_key = ENV['MERCURE_PUBLISHER_KEY']
-  config.subscriber_key = ENV['MERCURE_SUBSCRIBER_KEY']
+  config.mercure_domain = ENV['MERCURE_DOMAIN'] || raise('MERCURE_DOMAIN is not set')
+  config.publisher_key = ENV['MERCURE_PUBLISHER_KEY'] || raise('MERCURE_PUBLISHER_KEY is not set')
+  config.subscriber_key = ENV['MERCURE_SUBSCRIBER_KEY'] || raise('MERCURE_SUBSCRIBER_KEY is not set')
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,19 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_07_120410) do
+ActiveRecord::Schema.define(version: 2022_12_07_120410) do
+
   create_table "messages", force: :cascade do |t|
     t.string "text"
     t.integer "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "messages", "users"

--- a/test/train/broadcastable_test.rb
+++ b/test/train/broadcastable_test.rb
@@ -1,0 +1,253 @@
+require "test_helper"
+
+class BroadcastableTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper, Turbo::Streams::ActionHelper, Turbo::Train::TestHelper
+
+  setup do
+    @user = User.create! name: "John"
+    @message = Message.create! user: @user, text: "Hey Bob!"
+    @message.class.include Turbo::Train::Broadcastable
+  end
+
+  test 'train_broadcasts' do
+    Message.class_eval do
+      train_broadcasts content: 'content'
+    end
+
+    new_msg = nil
+    assert_broadcast_on 'messages', turbo_stream_action_tag("append", target: "messages", template: "content") do
+      perform_enqueued_jobs do
+        new_msg = Message.create! user: @user, text: "Hey Bob!"
+      end
+    end
+
+    assert_broadcast_on new_msg, turbo_stream_action_tag("replace", target: "message_#{new_msg.id}", template: "content") do
+      perform_enqueued_jobs do
+        new_msg.update!(text: "Hey Bob2!")
+      end
+    end
+
+    assert_broadcast_on new_msg, turbo_stream_action_tag("remove", target: "message_#{new_msg.id}") do
+      new_msg.destroy
+    end
+  end
+
+  test 'train_broadcasts_to' do
+    Message.class_eval do
+      train_broadcasts_to :user, content: 'content'
+    end
+
+    new_msg = nil
+    assert_broadcast_on @user, turbo_stream_action_tag("append", target: "messages", template: "content") do
+      perform_enqueued_jobs do
+        new_msg = Message.create! user: @user, text: "Hey Bob!"
+      end
+    end
+
+    assert_broadcast_on @user, turbo_stream_action_tag("replace", target: "message_#{new_msg.id}", template: "content") do
+      perform_enqueued_jobs do
+        new_msg.update!(text: "Hey Bob2!")
+      end
+    end
+
+    assert_broadcast_on @user, turbo_stream_action_tag("remove", target: "message_#{new_msg.id}") do
+      new_msg.destroy
+    end
+  end
+
+
+  test "train_broadcast_render_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "message_1", template: "Goodbye!") do
+      @message.train_broadcast_render_to @message
+    end
+  end
+
+  test "train_broadcast_render" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "message_1", template: "Goodbye!") do
+      @message.train_broadcast_render
+    end
+  end
+
+  test "broadcast_action_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
+      @message.train_broadcast_action_to(@message, action: 'replace', target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_action" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
+      @message.train_broadcast_action('replace', target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_append_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("append", target: "target", template: 'content') do
+      @message.train_broadcast_append_to(@message, target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_append" do
+    assert_broadcast_on @message, turbo_stream_action_tag("append", target: "target", template: 'content') do
+      @message.train_broadcast_append(target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_remove_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("remove", target: "message_#{@message.id}") do
+      @message.train_broadcast_remove_to(@message)
+    end
+  end
+
+  test "broadcast_remove" do
+    assert_broadcast_on @message, turbo_stream_action_tag("remove", target: "message_#{@message.id}") do
+      @message.train_broadcast_remove
+    end
+  end
+
+  test "broadcast_replace_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
+      @message.train_broadcast_replace_to(@message, target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_replace" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
+      @message.train_broadcast_replace(target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_update_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("update", target: "target", template: 'content') do
+      @message.train_broadcast_update_to(@message, target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_update" do
+    assert_broadcast_on @message, turbo_stream_action_tag("update", target: "target", template: 'content') do
+      @message.train_broadcast_update(target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_before_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("before", target: "target", template: 'content') do
+      @message.train_broadcast_before_to(@message, target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_after_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("after", target: "target", template: 'content') do
+      @message.train_broadcast_after_to(@message, target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_prepend_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("prepend", target: "target", template: 'content') do
+      @message.train_broadcast_prepend_to(@message, target: 'target', content: 'content')
+    end
+  end
+
+  test "broadcast_prepend" do
+    assert_broadcast_on @message, turbo_stream_action_tag("prepend", target: "target", template: 'content') do
+      @message.train_broadcast_prepend(target: 'target', content: 'content')
+    end
+  end
+
+  # later
+
+  test "broadcast_replace_later_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_replace_later_to(@message, target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_replace_later" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_replace_later(target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_update_later_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("update", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_update_later_to(@message, target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_update_later" do
+    assert_broadcast_on @message, turbo_stream_action_tag("update", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_update_later(target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_append_later_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("append", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_append_later_to(@message, target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_append_later" do
+    assert_broadcast_on @message, turbo_stream_action_tag("append", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_append_later(target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_prepend_later_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("prepend", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_prepend_later_to(@message, target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_prepend_later" do
+    assert_broadcast_on @message, turbo_stream_action_tag("prepend", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_prepend_later(target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_action_later_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_action_later_to(@message, action: 'replace', target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "broadcast_action_later" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
+      perform_enqueued_jobs do
+        @message.train_broadcast_action_later(action: 'replace', target: 'target', content: 'content')
+      end
+    end
+  end
+
+  test "train_broadcast_render_later_to" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "message_1", template: "Goodbye!") do
+      perform_enqueued_jobs do
+        @message.train_broadcast_render_later_to(@message, partial: 'messages/message', locals: { message: @message })
+      end
+    end
+  end
+
+  test "train_broadcast_render_later" do
+    assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "message_1", template: "Goodbye!") do
+      perform_enqueued_jobs do
+        @message.train_broadcast_render_later(partial: 'messages/message', locals: { message: @message })
+      end
+    end
+  end
+
+end

--- a/test/train/broadcastable_test.rb
+++ b/test/train/broadcastable_test.rb
@@ -68,85 +68,85 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_action_to" do
+  test "train_broadcast_action_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
       @message.train_broadcast_action_to(@message, action: 'replace', target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_action" do
+  test "train_broadcast_action" do
     assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
       @message.train_broadcast_action('replace', target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_append_to" do
+  test "train_broadcast_append_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("append", target: "target", template: 'content') do
       @message.train_broadcast_append_to(@message, target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_append" do
+  test "train_broadcast_append" do
     assert_broadcast_on @message, turbo_stream_action_tag("append", target: "target", template: 'content') do
       @message.train_broadcast_append(target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_remove_to" do
+  test "train_broadcast_remove_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("remove", target: "message_#{@message.id}") do
       @message.train_broadcast_remove_to(@message)
     end
   end
 
-  test "broadcast_remove" do
+  test "train_broadcast_remove" do
     assert_broadcast_on @message, turbo_stream_action_tag("remove", target: "message_#{@message.id}") do
       @message.train_broadcast_remove
     end
   end
 
-  test "broadcast_replace_to" do
+  test "train_broadcast_replace_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
       @message.train_broadcast_replace_to(@message, target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_replace" do
+  test "train_broadcast_replace" do
     assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
       @message.train_broadcast_replace(target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_update_to" do
+  test "train_broadcast_update_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("update", target: "target", template: 'content') do
       @message.train_broadcast_update_to(@message, target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_update" do
+  test "train_broadcast_update" do
     assert_broadcast_on @message, turbo_stream_action_tag("update", target: "target", template: 'content') do
       @message.train_broadcast_update(target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_before_to" do
+  test "train_broadcast_before_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("before", target: "target", template: 'content') do
       @message.train_broadcast_before_to(@message, target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_after_to" do
+  test "train_broadcast_after_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("after", target: "target", template: 'content') do
       @message.train_broadcast_after_to(@message, target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_prepend_to" do
+  test "train_broadcast_prepend_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("prepend", target: "target", template: 'content') do
       @message.train_broadcast_prepend_to(@message, target: 'target', content: 'content')
     end
   end
 
-  test "broadcast_prepend" do
+  test "train_broadcast_prepend" do
     assert_broadcast_on @message, turbo_stream_action_tag("prepend", target: "target", template: 'content') do
       @message.train_broadcast_prepend(target: 'target', content: 'content')
     end
@@ -154,7 +154,7 @@ class BroadcastableTest < ActiveSupport::TestCase
 
   # later
 
-  test "broadcast_replace_later_to" do
+  test "train_broadcast_replace_later_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_replace_later_to(@message, target: 'target', content: 'content')
@@ -162,7 +162,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_replace_later" do
+  test "train_broadcast_replace_later" do
     assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_replace_later(target: 'target', content: 'content')
@@ -170,7 +170,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_update_later_to" do
+  test "train_broadcast_update_later_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("update", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_update_later_to(@message, target: 'target', content: 'content')
@@ -178,7 +178,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_update_later" do
+  test "train_broadcast_update_later" do
     assert_broadcast_on @message, turbo_stream_action_tag("update", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_update_later(target: 'target', content: 'content')
@@ -186,7 +186,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_append_later_to" do
+  test "train_broadcast_append_later_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("append", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_append_later_to(@message, target: 'target', content: 'content')
@@ -194,7 +194,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_append_later" do
+  test "train_broadcast_append_later" do
     assert_broadcast_on @message, turbo_stream_action_tag("append", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_append_later(target: 'target', content: 'content')
@@ -202,7 +202,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_prepend_later_to" do
+  test "train_broadcast_prepend_later_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("prepend", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_prepend_later_to(@message, target: 'target', content: 'content')
@@ -210,7 +210,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_prepend_later" do
+  test "train_broadcast_prepend_later" do
     assert_broadcast_on @message, turbo_stream_action_tag("prepend", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_prepend_later(target: 'target', content: 'content')
@@ -218,7 +218,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_action_later_to" do
+  test "train_broadcast_action_later_to" do
     assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_action_later_to(@message, action: 'replace', target: 'target', content: 'content')
@@ -226,7 +226,7 @@ class BroadcastableTest < ActiveSupport::TestCase
     end
   end
 
-  test "broadcast_action_later" do
+  test "train_broadcast_action_later" do
     assert_broadcast_on @message, turbo_stream_action_tag("replace", target: "target", template: 'content') do
       perform_enqueued_jobs do
         @message.train_broadcast_action_later(action: 'replace', target: 'target', content: 'content')

--- a/test/train/broadcasts_test.rb
+++ b/test/train/broadcasts_test.rb
@@ -33,8 +33,8 @@ class BroadcastsTest < ActiveSupport::TestCase
   end
 
   test "broadcast_remove_to" do
-    assert_broadcast_on 'messages', turbo_stream_action_tag("remove", target: "target", template: 'content') do
-      r = Turbo::Train.broadcast_remove_to('messages', target: 'target', content: 'content')
+    assert_broadcast_on 'messages', turbo_stream_action_tag("remove", target: "target") do
+      r = Turbo::Train.broadcast_remove_to('messages', target: 'target')
       assert_equal r.code, '200'
       assert_match /urn:uuid:.*/, r.body
     end

--- a/test/train/broadcasts_test.rb
+++ b/test/train/broadcasts_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class BroadcastsTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper, Turbo::Streams::ActionHelper, Turbo::Train::TestHelper
+
+  test "broadcasting render" do
+    user_john = User.create! name: "John"
+    user_bob = User.create! name: "Bob"
+
+    message_1 = Message.create! user: user_john, text: "Hey Bob!"
+
+    r = Turbo::Train.broadcast_render_to( message_1, partial: 'messages/message', locals: { message: message_1 } )
+    assert_broadcast_on
+    assert_equal r.code, '200'
+    assert_match /urn:uuid:.*/, r.body
+  end
+
+  test "broadcasting action" do
+    train_assert_broadcast_on 'messages', turbo_stream_action_tag("append", target: "target", template: 'content') do
+      r = Turbo::Train.broadcast_append_to('messages', target: 'target', content: 'content')
+      assert_equal r.code, '200'
+      assert_match /urn:uuid:.*/, r.body
+    end
+    # BROADCAST_TO_METHODS = %w(broadcast_append_to broadcast_remove_to broadcast_replace_to broadcast_update_to broadcast_before_to broadcast_after_to broadcast_prepend_to).freeze
+    #
+    # BROADCAST_TO_METHODS.each do |method|
+    #   assert_respond_to Turbo::Train, method
+    #
+    #   r = Turbo::Train.public_send(method, 'messages', target: 'target', content: 'content')
+    #
+    #   assert_equal r.code, '200'
+    #   assert_match /urn:uuid:.*/, r.body
+    # end
+  end
+
+  test "broadcasting action later" do
+    BROADCAST_LATER_TO_METHODS = %w(
+      broadcast_replace_later_to broadcast_remove_later_to broadcast_update_later_to
+      broadcast_before_later_to broadcast_after_later_to
+      broadcast_append_later_to broadcast_prepend_later_to
+    ).freeze
+
+    BROADCAST_LATER_TO_METHODS.each do |method|
+      assert_respond_to Turbo::Train, method
+
+      Turbo::Train.public_send(method, 'messages', target: 'target', content: 'content')
+    end
+
+    assert_enqueued_jobs BROADCAST_LATER_TO_METHODS.size
+  end
+end


### PR DESCRIPTION
## Description

- Added full compatibility with rails `Turbo::Broadcastable` (with `train_` prefix)
- Added new test helpers and test server
- Added ruby 3.2.2 to test matrix
- Fixed all CI tests

Closes #5 