### PR TITLE
Fix configure initializer + Add fanout to setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
      src="https://user-images.githubusercontent.com/3010927/210603861-4b265489-a4a7-4d2a-bceb-40ceccebcd96.jpg">
 
 
-Real-time page updates for your Rails app over SSE with [Mercure](https://mercure.rocks) and [Hotwire Turbo](https://turbo.hotwired.dev/handbook/streams#integration-with-server-side-frameworks).
+Real-time page updates for your Rails app over SSE with [Mercure](https://mercure.rocks) or [Fanout Cloud](https://fanout.io/cloud) and [Hotwire Turbo](https://turbo.hotwired.dev/handbook/streams#integration-with-server-side-frameworks).
 
 * **Uses [SSE](https://html.spec.whatwg.org/multipage/server-sent-events.html)**. No more websockets, client libraries, JS code and handling reconnects. Just an HTTP connection. Let the [browser](https://caniuse.com/eventsource) do the work.
 * **Seamless Hotwire integration.** Use it exactly like [ActionCable](https://github.com/hotwired/turbo-rails#come-alive-with-turbo-streams). Drop-in replacement for `broadcast_action_to` and usual helpers.
@@ -16,7 +16,7 @@ Real-time page updates for your Rails app over SSE with [Mercure](https://mercur
 
 Using this gem requires some knowledge of ActionCable and broadcasting turbo streams. Turbo::Train is designed to mimic those, so it is highly recommended to first try the original to understand the concept.
 
-You can start [here](https://hotwired.dev/) and proceed with the [Turbo Handbook](https://turbo.hotwired.dev/handbook/introduction). One of its chapters will be covering [Turbo Streams](https://turbo.hotwired.dev/handbook/streams). Specifically [this section](https://turbo.hotwired.dev/handbook/streams#integration-with-server-side-frameworks) would be the main prerequisite to understanding what this gem is about: it covers [Broadcastable](https://github.com/hotwired/turbo-rails/blob/main/app/models/concerns/turbo/broadcastable.rb) and the overall idea of working with Mercure.
+You can start [here](https://hotwired.dev/) and proceed with the [Turbo Handbook](https://turbo.hotwired.dev/handbook/introduction). One of its chapters will be covering [Turbo Streams](https://turbo.hotwired.dev/handbook/streams). Specifically [this section](https://turbo.hotwired.dev/handbook/streams#integration-with-server-side-frameworks) would be the main prerequisite to understanding what this gem is about: it covers [Broadcastable](https://github.com/hotwired/turbo-rails/blob/main/app/models/concerns/turbo/broadcastable.rb) and the overall idea of working with Mercure or Fanout Cloud.
 
 ## Prerequisites
 
@@ -58,10 +58,13 @@ Now you are ready to run 🚀
 ```
 caddy run
 ```
-#### Fanout
+#### Fanout Cloud
 
-[Fanout](https://fanout.io/) is a cloud platform. To use Fanout you must purchase a paid account with a contract for Fastly's services.
+We only support the cloud version today. To use [Fanout](https://fanout.io/cloud/) you must purchase a paid account with a contract for Fastly's services.
 
+#### Fanout self-hosted (Pushpin)
+
+Coming soon.
 ## Usage
 
 If you are familiar with broadcasting from ActionCable, usage would be extremely familiar:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 <img align="right" width="220" title="Turbo::Train logo"
      src="https://user-images.githubusercontent.com/3010927/210603861-4b265489-a4a7-4d2a-bceb-40ceccebcd96.jpg">
-     
+
 
 Real-time page updates for your Rails app over SSE with [Mercure](https://mercure.rocks) and [Hotwire Turbo](https://turbo.hotwired.dev/handbook/streams#integration-with-server-side-frameworks).
 
 * **Uses [SSE](https://html.spec.whatwg.org/multipage/server-sent-events.html)**. No more websockets, client libraries, JS code and handling reconnects. Just an HTTP connection. Let the [browser](https://caniuse.com/eventsource) do the work.
 * **Seamless Hotwire integration.** Use it exactly like [ActionCable](https://github.com/hotwired/turbo-rails#come-alive-with-turbo-streams). Drop-in replacement for `broadcast_action_to` and usual helpers.
-* **Simple.** Get running in minutes, scale easily in production 🚀 
+* **Simple.** Get running in minutes, scale easily in production 🚀
 
 ## Before your proceed
 
@@ -40,7 +40,8 @@ Instructions for Rails 6
 1. Install [turbo-rails](https://github.com/hotwired/turbo-rails#installation)
 2. Repeat steps for Rails 7 above
 
-### Step 2. Mercure
+### Step 2. Server
+#### Mercure
 
 Mercure is installed as a plugin to [Caddy](https://github.com/caddyserver/caddy) server. For mac users everything is pretty easy:
 
@@ -57,6 +58,9 @@ Now you are ready to run 🚀
 ```
 caddy run
 ```
+#### Fanout
+
+[Fanout](https://fanout.io/) is a cloud platform. To use Fanout you must purchase a paid account with a contract for Fastly's services.
 
 ## Usage
 
@@ -98,17 +102,30 @@ You have the same options as original Rails Turbo helpers: rendering partials, p
 
 ## Configuration
 
-To specify different Mercure server settings, please adjust the generated `config/initializers/turbo_train.rb` file:
+To specify different Mercure or Fanout server settings, please adjust the generated `config/initializers/turbo_train.rb` file:
 
 ```ruby
 Turbo::Train.configure do |config|
-  config.mercure_domain = ...
-  config.publisher_key = ...
-  config.subscriber_key = ...
+  config.skip_ssl_verification = true # Development only; don't do this in production
+  config.default_server = :fanout # Default value is :mercure
+
+  config.server :mercure do |mercure|
+    mercure.mercure_domain = ...
+    mercure.publisher_key = ...
+    mercure.subscriber_key = ...
+  end
+
+  config.server :fanout do |fanout|
+    fanout.service_url = ...
+    fanout.service_id = ...
+    fanout.fastly_key = ...
+  end
 end
 ```
 
-* Your SSE will connect to `https://#{configuration.mercure_domain}/.well-known`. 
+### Mercure
+
+* Your SSE will connect to `https://#{configuration.mercure_domain}/.well-known`.
 * The publisher/subscriber key correspond to the [configuration](https://mercure.rocks/docs/hub/config) or your Mercure server.
 
 By default, these are set to `localhost`/`test`/`testing` to match the configuration of the local development server from the installation instructions above.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ We only support the cloud version today. To use [Fanout](https://fanout.io/cloud
 #### Fanout self-hosted (Pushpin)
 
 Coming soon.
+
 ## Usage
 
 If you are familiar with broadcasting from ActionCable, usage would be extremely familiar:

--- a/lib/install/create_initializer.rb
+++ b/lib/install/create_initializer.rb
@@ -2,20 +2,10 @@ say "Creating initializer"
 create_file Rails.root.join("config/initializers/turbo_train.rb") do
   %{
 Turbo::Train.configure do |config|
+  config.mercure_domain = 'localhost'
+  config.publisher_key = 'testing'
+  config.subscriber_key = 'test'
   config.skip_ssl_verification = true # Development only; don't do this in production
-  config.default_server = :mercure # Default value is :mercure
-
-  config.server :mercure do |mercure|
-    mercure.mercure_domain = 'localhost'
-    mercure.publisher_key = 'testing'
-    mercure.subscriber_key = 'test'
-  end
-
-  config.server :fanout do |fanout|
-    fanout.service_url = ''
-    fanout.service_id = ''
-    fanout.fastly_key = ''
-  end
 end
   }
 end

--- a/lib/install/create_initializer.rb
+++ b/lib/install/create_initializer.rb
@@ -3,7 +3,7 @@ create_file Rails.root.join("config/initializers/turbo_train.rb") do
   %{
 Turbo::Train.configure do |config|
   config.skip_ssl_verification = true # Development only; don't do this in production
-  config.default_server =  # Default value is :mercure
+  config.default_server = :mercure # Default value is :mercure
 
   config.server :mercure do |mercure|
     mercure.mercure_domain = 'localhost'

--- a/lib/install/create_initializer.rb
+++ b/lib/install/create_initializer.rb
@@ -2,10 +2,20 @@ say "Creating initializer"
 create_file Rails.root.join("config/initializers/turbo_train.rb") do
   %{
 Turbo::Train.configure do |config|
-  config.mercure_domain = 'localhost'
-  config.publisher_key = 'testing'
-  config.subscriber_key = 'test'
   config.skip_ssl_verification = true # Development only; don't do this in production
+  config.default_server =  # Default value is :mercure
+
+  config.server :mercure do |mercure|
+    mercure.mercure_domain = 'localhost'
+    mercure.publisher_key = 'testing'
+    mercure.subscriber_key = 'test'
+  end
+
+  config.server :fanout do |fanout|
+    fanout.service_url = ''
+    fanout.service_id = ''
+    fanout.fastly_key = ''
+  end
 end
   }
 end


### PR DESCRIPTION
2 issues are fixing here:
- Current initialized confige should be under the block with setting server.
- Readme doesn't have any word about fanout implementation

Should we add something about fanout into `Configuration` block in Readme?

P.S it's my first experience in contributing to gem, please, don't judge me strong 😄 
